### PR TITLE
Rolling back namespace renaming changes

### DIFF
--- a/App/Activation/ActivationHandler.cs
+++ b/App/Activation/ActivationHandler.cs
@@ -1,4 +1,4 @@
-﻿namespace MilkyLabs.Quotes.App.Activation;
+﻿namespace MilkyLabs.Quotes.Activation;
 
 // Extend this class to implement new ActivationHandlers. See DefaultActivationHandler for an example.
 // https://github.com/microsoft/TemplateStudio/blob/main/docs/WinUI/activation.md

--- a/App/Activation/DefaultActivationHandler.cs
+++ b/App/Activation/DefaultActivationHandler.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.UI.Xaml;
-using MilkyLabs.Quotes.App.Contracts.Services;
-using MilkyLabs.Quotes.App.ViewModels;
+using MilkyLabs.Quotes.Contracts.Services;
+using MilkyLabs.Quotes.ViewModels;
 
-namespace MilkyLabs.Quotes.App.Activation;
+namespace MilkyLabs.Quotes.Activation;
 
 public class DefaultActivationHandler : ActivationHandler<LaunchActivatedEventArgs>
 {

--- a/App/Activation/IActivationHandler.cs
+++ b/App/Activation/IActivationHandler.cs
@@ -1,4 +1,4 @@
-﻿namespace MilkyLabs.Quotes.App.Activation;
+﻿namespace MilkyLabs.Quotes.Activation;
 
 public interface IActivationHandler
 {

--- a/App/App.csproj
+++ b/App/App.csproj
@@ -12,7 +12,7 @@
 	<Nullable>enable</Nullable>
 	<UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
-    <RootNamespace>MilkyLabs.Quotes.App</RootNamespace>
+    <RootNamespace>MilkyLabs.Quotes</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/App/App.xaml
+++ b/App/App.xaml
@@ -1,5 +1,5 @@
 ﻿<Application
-    x:Class="MilkyLabs.Quotes.App.App"
+    x:Class="MilkyLabs.Quotes.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>

--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -1,16 +1,16 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.UI.Xaml;
-using MilkyLabs.Quotes.App.Activation;
-using MilkyLabs.Quotes.App.Contracts.Services;
-using MilkyLabs.Quotes.App.Services;
-using MilkyLabs.Quotes.App.ViewModels;
-using MilkyLabs.Quotes.App.Views;
-using MilkyLabs.Quotes.App.Core.Contracts.Services;
-using MilkyLabs.Quotes.App.Core.Services;
-using MilkyLabs.Quotes.App.Helpers;
+using MilkyLabs.Quotes.Activation;
+using MilkyLabs.Quotes.Contracts.Services;
+using MilkyLabs.Quotes.Services;
+using MilkyLabs.Quotes.ViewModels;
+using MilkyLabs.Quotes.Views;
+using MilkyLabs.Quotes.Core.Contracts.Services;
+using MilkyLabs.Quotes.Core.Services;
+using MilkyLabs.Quotes.Helpers;
 
-namespace MilkyLabs.Quotes.App;
+namespace MilkyLabs.Quotes;
 
 // To learn more about WinUI 3, see https://docs.microsoft.com/windows/apps/winui/winui3/.
 public partial class App : Application

--- a/App/Behaviors/NavigationViewHeaderBehavior.cs
+++ b/App/Behaviors/NavigationViewHeaderBehavior.cs
@@ -2,9 +2,9 @@
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using Microsoft.Xaml.Interactivity;
-using MilkyLabs.Quotes.App.Contracts.Services;
+using MilkyLabs.Quotes.Contracts.Services;
 
-namespace MilkyLabs.Quotes.App.Behaviors;
+namespace MilkyLabs.Quotes.Behaviors;
 
 public class NavigationViewHeaderBehavior : Behavior<NavigationView>
 {

--- a/App/Behaviors/NavigationViewHeaderMode.cs
+++ b/App/Behaviors/NavigationViewHeaderMode.cs
@@ -1,4 +1,4 @@
-﻿namespace MilkyLabs.Quotes.App.Behaviors;
+﻿namespace MilkyLabs.Quotes.Behaviors;
 
 public enum NavigationViewHeaderMode
 {

--- a/App/Contracts/Services/IActivationService.cs
+++ b/App/Contracts/Services/IActivationService.cs
@@ -1,4 +1,4 @@
-﻿namespace MilkyLabs.Quotes.App.Contracts.Services;
+﻿namespace MilkyLabs.Quotes.Contracts.Services;
 
 public interface IActivationService
 {

--- a/App/Contracts/Services/INavigationService.cs
+++ b/App/Contracts/Services/INavigationService.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 
-namespace MilkyLabs.Quotes.App.Contracts.Services;
+namespace MilkyLabs.Quotes.Contracts.Services;
 
 public interface INavigationService
 {

--- a/App/Contracts/Services/INavigationViewService.cs
+++ b/App/Contracts/Services/INavigationViewService.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.UI.Xaml.Controls;
 
-namespace MilkyLabs.Quotes.App.Contracts.Services;
+namespace MilkyLabs.Quotes.Contracts.Services;
 
 public interface INavigationViewService
 {

--- a/App/Contracts/Services/IPageService.cs
+++ b/App/Contracts/Services/IPageService.cs
@@ -1,4 +1,4 @@
-﻿namespace MilkyLabs.Quotes.App.Contracts.Services;
+﻿namespace MilkyLabs.Quotes.Contracts.Services;
 
 public interface IPageService
 {

--- a/App/Contracts/ViewModels/INavigationAware.cs
+++ b/App/Contracts/ViewModels/INavigationAware.cs
@@ -1,4 +1,4 @@
-﻿namespace MilkyLabs.Quotes.App.Contracts.ViewModels;
+﻿namespace MilkyLabs.Quotes.Contracts.ViewModels;
 
 public interface INavigationAware
 {

--- a/App/Helpers/FrameExtensions.cs
+++ b/App/Helpers/FrameExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.UI.Xaml.Controls;
 
-namespace MilkyLabs.Quotes.App.Helpers;
+namespace MilkyLabs.Quotes.Helpers;
 
 public static class FrameExtensions
 {

--- a/App/Helpers/NavigationHelper.cs
+++ b/App/Helpers/NavigationHelper.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
-namespace MilkyLabs.Quotes.App.Helpers;
+namespace MilkyLabs.Quotes.Helpers;
 
 // Helper class to set the navigation target for a NavigationViewItem.
 //

--- a/App/Helpers/ResourceExtensions.cs
+++ b/App/Helpers/ResourceExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Windows.ApplicationModel.Resources;
 
-namespace MilkyLabs.Quotes.App.Helpers;
+namespace MilkyLabs.Quotes.Helpers;
 
 public static class ResourceExtensions
 {

--- a/App/Helpers/RuntimeHelper.cs
+++ b/App/Helpers/RuntimeHelper.cs
@@ -1,7 +1,7 @@
 ﻿using System.Runtime.InteropServices;
 using System.Text;
 
-namespace MilkyLabs.Quotes.App.Helpers;
+namespace MilkyLabs.Quotes.Helpers;
 
 public class RuntimeHelper
 {

--- a/App/Helpers/TitleBarHelper.cs
+++ b/App/Helpers/TitleBarHelper.cs
@@ -7,7 +7,7 @@ using Microsoft.UI.Xaml.Media;
 using Windows.UI;
 using Windows.UI.ViewManagement;
 
-namespace MilkyLabs.Quotes.App.Helpers;
+namespace MilkyLabs.Quotes.Helpers;
 
 // Helper class to workaround custom title bar bugs.
 // DISCLAIMER: The resource key names and color values used below are subject to change. Do not depend on them.

--- a/App/MainWindow.xaml.cs
+++ b/App/MainWindow.xaml.cs
@@ -1,7 +1,7 @@
 ﻿using Windows.UI.ViewManagement;
-using MilkyLabs.Quotes.App.Helpers;
+using MilkyLabs.Quotes.Helpers;
 
-namespace MilkyLabs.Quotes.App;
+namespace MilkyLabs.Quotes;
 
 public sealed partial class MainWindow : WindowEx
 {

--- a/App/Services/ActivationService.cs
+++ b/App/Services/ActivationService.cs
@@ -1,10 +1,10 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using MilkyLabs.Quotes.App.Activation;
-using MilkyLabs.Quotes.App.Contracts.Services;
-using MilkyLabs.Quotes.App.Views;
+using MilkyLabs.Quotes.Activation;
+using MilkyLabs.Quotes.Contracts.Services;
+using MilkyLabs.Quotes.Views;
 
-namespace MilkyLabs.Quotes.App.Services;
+namespace MilkyLabs.Quotes.Services;
 
 public class ActivationService : IActivationService
 {

--- a/App/Services/NavigationService.cs
+++ b/App/Services/NavigationService.cs
@@ -2,11 +2,11 @@
 
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
-using MilkyLabs.Quotes.App.Contracts.Services;
-using MilkyLabs.Quotes.App.Contracts.ViewModels;
-using MilkyLabs.Quotes.App.Helpers;
+using MilkyLabs.Quotes.Contracts.Services;
+using MilkyLabs.Quotes.Contracts.ViewModels;
+using MilkyLabs.Quotes.Helpers;
 
-namespace MilkyLabs.Quotes.App.Services;
+namespace MilkyLabs.Quotes.Services;
 
 // For more information on navigation between pages see
 // https://github.com/microsoft/TemplateStudio/blob/main/docs/WinUI/navigation.md

--- a/App/Services/NavigationViewService.cs
+++ b/App/Services/NavigationViewService.cs
@@ -1,11 +1,11 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.UI.Xaml.Controls;
-using MilkyLabs.Quotes.App.Contracts.Services;
-using MilkyLabs.Quotes.App.Helpers;
-using MilkyLabs.Quotes.App.ViewModels;
+using MilkyLabs.Quotes.Contracts.Services;
+using MilkyLabs.Quotes.Helpers;
+using MilkyLabs.Quotes.ViewModels;
 
-namespace MilkyLabs.Quotes.App.Services;
+namespace MilkyLabs.Quotes.Services;
 
 public class NavigationViewService : INavigationViewService
 {

--- a/App/Services/PageService.cs
+++ b/App/Services/PageService.cs
@@ -1,11 +1,11 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 
 using Microsoft.UI.Xaml.Controls;
-using MilkyLabs.Quotes.App.Contracts.Services;
-using MilkyLabs.Quotes.App.ViewModels;
-using MilkyLabs.Quotes.App.Views;
+using MilkyLabs.Quotes.Contracts.Services;
+using MilkyLabs.Quotes.ViewModels;
+using MilkyLabs.Quotes.Views;
 
-namespace MilkyLabs.Quotes.App.Services;
+namespace MilkyLabs.Quotes.Services;
 
 public class PageService : IPageService
 {

--- a/App/ViewModels/MainViewModel.cs
+++ b/App/ViewModels/MainViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 
-namespace MilkyLabs.Quotes.App.ViewModels;
+namespace MilkyLabs.Quotes.ViewModels;
 
 public partial class MainViewModel : ObservableRecipient
 {

--- a/App/ViewModels/ShellViewModel.cs
+++ b/App/ViewModels/ShellViewModel.cs
@@ -1,10 +1,10 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 
 using Microsoft.UI.Xaml.Navigation;
-using MilkyLabs.Quotes.App.Contracts.Services;
-using MilkyLabs.Quotes.App.Views;
+using MilkyLabs.Quotes.Contracts.Services;
+using MilkyLabs.Quotes.Views;
 
-namespace MilkyLabs.Quotes.App.ViewModels;
+namespace MilkyLabs.Quotes.ViewModels;
 
 public partial class ShellViewModel : ObservableRecipient
 {

--- a/App/Views/MainPage.xaml.cs
+++ b/App/Views/MainPage.xaml.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.UI.Xaml.Controls;
-using MilkyLabs.Quotes.App.ViewModels;
+using MilkyLabs.Quotes.ViewModels;
 
-namespace MilkyLabs.Quotes.App.Views;
+namespace MilkyLabs.Quotes.Views;
 
 public sealed partial class MainPage : Page
 {

--- a/App/Views/ShellPage.xaml.cs
+++ b/App/Views/ShellPage.xaml.cs
@@ -3,11 +3,11 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Windows.System;
-using MilkyLabs.Quotes.App.Contracts.Services;
-using MilkyLabs.Quotes.App.Helpers;
-using MilkyLabs.Quotes.App.ViewModels;
+using MilkyLabs.Quotes.Contracts.Services;
+using MilkyLabs.Quotes.Helpers;
+using MilkyLabs.Quotes.ViewModels;
 
-namespace MilkyLabs.Quotes.App.Views;
+namespace MilkyLabs.Quotes.Views;
 
 // TODO: Update NavigationViewItem titles and icons in ShellPage.xaml.
 public sealed partial class ShellPage : Page


### PR DESCRIPTION
Откатил изменения переименования namespace, потому что это вызвало много ошибок в коде